### PR TITLE
Changed Install Target version range from [14.0,17.0] to [14.0,17.0)

### DIFF
--- a/VSIXProject1/source.extension.vsixmanifest
+++ b/VSIXProject1/source.extension.vsixmanifest
@@ -8,9 +8,9 @@
         <PreviewImage>screenshot.PNG</PreviewImage>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[14.0,17.0]" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[14.0,17.0]" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[14.0,17.0]" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Changed Install Target version range from [14.0,17.0] to [14.0,17.0) so that extension can be installed in Visual Studio 2019 while Visual Studio 2022 is also present.

This extension is not compatible with Visual Studio 2022 (Visual Studio 2022 is 64-bit) and if install target looks like [14.0,17.0] the extension will not be installed in any version of Visual Studio.